### PR TITLE
Ensure presets are taken from where the .exe lives

### DIFF
--- a/BinxelviewForm.cs
+++ b/BinxelviewForm.cs
@@ -784,7 +784,7 @@ namespace Binxelview
             }
 
             presets = new List<Preset>();
-            DirectoryInfo d = new DirectoryInfo(".");
+            DirectoryInfo d = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
             FileInfo[] files = d.GetFiles("*.bxp");
             foreach (FileInfo file in files)
             {

--- a/BinxelviewForm.cs
+++ b/BinxelviewForm.cs
@@ -784,18 +784,36 @@ namespace Binxelview
             }
 
             presets = new List<Preset>();
-            DirectoryInfo d = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
-            FileInfo[] files = d.GetFiles("*.bxp");
+            DirectoryInfo d_cwd = new DirectoryInfo(".");
+            DirectoryInfo d_app = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+            FileInfo[] files_cwd = d_cwd.GetFiles("*.bxp");
+            FileInfo[] files_app = d_app.GetFiles("*.bxp");
+            FileInfo[] files = new FileInfo[files_cwd.Length+files_app.Length];
+            Array.Copy(files_cwd,0,files,0,files_cwd.Length);
+            Array.Copy(files_app,0,files,files_cwd.Length,files_app.Length);
             foreach (FileInfo file in files)
             {
                 Preset p = new Preset();
                 if (p.loadFile(file.FullName))
                 {
-                    presets.Add(p);
-                    if (p.name.ToLower()=="default")
+                    bool duplicate = false;
+                    foreach (Preset pe in presets)
                     {
-                        default_preset = p.copy();
-                        scrollRange();
+                        if (pe.name == p.name)
+                        {
+                            duplicate = true;
+                            break;
+                        }
+                    }
+
+                    if (!duplicate)
+                    {
+                        presets.Add(p);
+                        if (p.name.ToLower()=="default")
+                        {
+                            default_preset = p.copy();
+                            scrollRange();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The current technique of using "." means that presets are loaded from the *current* directory.

If you are launching from the command line and BinXelView.exe is in your path this means it won't find the presets.

This change ensures it looks for the .bxp presets inside whichever directory BinXelView.exe resides.