### PR TITLE
Implement support for loading six-bit VGA palettes

### DIFF
--- a/BinxelviewForm.cs
+++ b/BinxelviewForm.cs
@@ -747,6 +747,10 @@ namespace Binxelview
                     r = r * 255 / 63;
                     g = g * 255 / 63;
                     b = b * 255 / 63;
+                    // Clamp, in case the data isn't entirely valid
+                    if (r > 255) r = 255;
+                    if (g > 255) g = 255;
+                    if (b > 255) b = 255;
                 }
                 setPalette(i, r, g, b);
             }

--- a/BinxelviewForm.cs
+++ b/BinxelviewForm.cs
@@ -689,7 +689,7 @@ namespace Binxelview
             }
         }
 
-        bool openPalette(string path, bool image)
+        bool openPalette(string path, bool image, bool sixbit_vga)
         {
             if (preset.bpp > PALETTE_BITS)
             {
@@ -741,6 +741,13 @@ namespace Binxelview
                 int r = read_data[(i * 3) + 0];
                 int g = read_data[(i * 3) + 1];
                 int b = read_data[(i * 3) + 2];
+                if (sixbit_vga)
+                {
+                    // Convert 18-bit VGA palette to 24-bit
+                    r = r * 255 / 63;
+                    g = g * 255 / 63;
+                    b = b * 255 / 63;
+                }
                 setPalette(i, r, g, b);
             }
             return true;
@@ -1427,10 +1434,11 @@ namespace Binxelview
             d.Filter =
                 "Palette, RGB24 (*.pal)|*.pal|" +
                 "Image (*.bmp;*.gif;*.png;*.tif)|*.bmp;*.gif;*.png;*.tif|" +
+                "VGA Palette, 6-bit RGB18 (*.*)|*.*|"+
                 "All files, RGB24 (*.*)|*.*";
             if (d.ShowDialog() == DialogResult.OK)
             {
-                if (openPalette(d.FileName,d.FilterIndex==2))
+                if (openPalette(d.FileName,d.FilterIndex==2,d.FilterIndex==3))
                 {
                     preparePalette();
                     redrawPixels();

--- a/readme.txt
+++ b/readme.txt
@@ -149,6 +149,7 @@ Changes
 - "Little Endian" renamed to "Reverse Byte" for clarity.
 - "Export Binary Chunk" option added to File menu. (Contributor: damieng)
 - Tab stop organization of interface. (Contributor: Erquint)
+- Palette load option for common VGA format. (Contributor: foone)
 
 1.5.0.0 (2020-07-31)
 - Twiddle option for inspecting textures stored with morton ordering of pixels.


### PR DESCRIPTION
DOS games often use VGA-style palettes, where the file is 768 bytes long because it's just 3 bytes for each palette entry, but since they're being sent directly to a VGA card (which only supports an 18-bit palette), each byte is only in the range 0-63. This palettes can be loaded already by Binxelview, but every color will be 1/4th as bright as it should. 

This patch adds a new option to the load-palette dialogue to let you select "VGA Palette, 6-bit RGB18". This is treated just like a standard 24bit palette, but each value in the palette will be converted from 6-bit to 8-bit on load, so you get the correct brightness. 
Tested with loading palettes from Lemmings 3D, and it worked perfectly. It shouldn't affect anything else so I didn't do any further testing. 

Palette saving wasn't touched, so if you load a 6-bit VGA palette and then save it back out, you'll get a standard 8-bits-per-channel PAL file